### PR TITLE
fix: align pre-commit configuration with Prettier for JSON formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,10 +21,6 @@ repos:
       - id: trailing-whitespace
         args: ['--markdown-linebreak-ext=md']
         exclude: ^package-lock\.json$
-      - id: pretty-format-json
-        args: ['--autofix', '--indent=2', '--no-ensure-ascii']
-        files: \.(json)$
-        exclude: ^package-lock\.json$
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.8.3
     hooks:
@@ -37,7 +33,7 @@ repos:
         name: Prettier
         entry: prettier
         language: node
-        files: ^src/.*\.(js|jsx|ts|tsx|mjs|cjs|css|scss|json)$
+        files: \.(js|jsx|ts|tsx|mjs|cjs|css|scss|json)$
         args: ['--write']
         additional_dependencies: ['prettier@^3.6.2']
         pass_filenames: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,11 +12,6 @@
     "strict": true,
     "target": "ES2020"
   },
-  "exclude": [
-    "node_modules",
-    "dist"
-  ],
-  "include": [
-    "src/**/*"
-  ]
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

- Remove conflicting `pretty-format-json` hook that used different JSON formatting rules than Prettier
- Expand Prettier hook file coverage from `^src/.*` to all files, ensuring consistent formatting across the entire codebase
- Fix duplicate JSON processing that was causing formatting inconsistencies between pre-commit and Prettier

## Problem

The current pre-commit configuration had two issues:

1. **Conflicting JSON formatters**: Both `pretty-format-json` (with `--indent=2 --no-ensure-ascii`) and Prettier were processing JSON files with different formatting rules
2. **Limited file coverage**: Prettier hook was restricted to `^src/.*` files, missing root-level JSON files like `package.json`, `tsconfig.json`

## Solution

- Removed the `pretty-format-json` hook to eliminate conflicts
- Updated Prettier hook file pattern from `^src/.*\.(js|jsx|ts|tsx|mjs|cjs|css|scss|json)$` to `\.(js|jsx|ts|tsx|mjs|cjs|css|scss|json)$`
- All JSON formatting now uses consistent Prettier configuration (2 spaces, proper bracket spacing, etc.)

## Test plan

- [x] Verified Prettier formats JSON files correctly with project configuration
- [x] Tested pre-commit hook runs successfully on JSON files
- [x] Confirmed no conflicts between different formatting tools

🤖 Generated with [Claude Code](https://claude.ai/code)