### PR TITLE
feat: support variable-free text input

### DIFF
--- a/src/interaction-parser.ts
+++ b/src/interaction-parser.ts
@@ -9,7 +9,7 @@
 
 // Interaction input type enumeration
 export enum InteractionType {
-  TEXT_ONLY = 'text_only', // Pure text input: ?[%{{var}}...question]
+  TEXT_ONLY = 'text_only', // Pure text input: ?[%{{var}}...question] or ?[...question]
   BUTTONS_ONLY = 'buttons_only', // Pure button group: ?[%{{var}} option1|option2]
   BUTTONS_WITH_TEXT = 'buttons_with_text', // Button group + text: ?[%{{var}} option1|option2|...question]
   BUTTONS_MULTI_SELECT = 'buttons_multi_select', // Multi-select buttons: ?[%{{var}} A||B]
@@ -56,7 +56,7 @@ export interface VariableInteractionResult extends ParseResultBase {
     | InteractionType.BUTTONS_WITH_TEXT
     | InteractionType.BUTTONS_MULTI_SELECT
     | InteractionType.BUTTONS_MULTI_WITH_TEXT;
-  variable: string;
+  variable?: string;
   buttons?: Button[];
   question?: string;
   isMultiSelect?: boolean;
@@ -166,9 +166,12 @@ export class InteractionParser {
       );
       remarkResult.buttonValues = nonAssignmentResult.buttons.map(b => b.value);
     } else if (result.type !== null) {
-      // Variable interaction
+      // Input or variable interaction
       const variableResult = result as VariableInteractionResult;
-      remarkResult.variableName = variableResult.variable;
+
+      if (variableResult.variable !== undefined) {
+        remarkResult.variableName = variableResult.variable;
+      }
 
       if (variableResult.buttons) {
         remarkResult.buttonTexts = variableResult.buttons.map(b => b.display);
@@ -316,12 +319,22 @@ export class InteractionParser {
    */
   private _layer3ParseDisplayButtons(
     content: string
-  ): NonAssignmentButtonResult {
+  ): NonAssignmentButtonResult | VariableInteractionResult {
     if (!content) {
       // Empty content: ?[]
       return {
         type: InteractionType.NON_ASSIGNMENT_BUTTON,
         buttons: [{ display: '', value: '' }],
+      };
+    }
+
+    const ellipsisMatch = COMPILED_REGEXES.LAYER3_ELLIPSIS.exec(content);
+    if (ellipsisMatch && !ellipsisMatch[1].trim()) {
+      // Pure text input without variable: ?[...question]
+      return {
+        type: InteractionType.TEXT_ONLY,
+        question: ellipsisMatch[2].trim(),
+        isMultiSelect: false,
       };
     }
 
@@ -475,7 +488,7 @@ export class InteractionParser {
  * Convenience function for parsing interaction format
  *
  * Supported formats:
- * 1. ?[%{{var}}...question] - Pure text input
+ * 1. ?[%{{var}}...question] or ?[...question] - Pure text input
  * 2. ?[%{{var}} option1|option2] - Pure button group (supports display//value format)
  * 3. ?[%{{var}} option1|option2|...question] - Button group + text input
  * 4. ?[%{{var}} option1||option2] - Multi-select button group

--- a/tests/parser-demo.test.ts
+++ b/tests/parser-demo.test.ts
@@ -20,6 +20,15 @@ describe('InteractionParser Sample and Test', () => {
       });
     });
 
+    test('Test Non-Variable Text Input Parsing', () => {
+      const result = parser.parseToRemarkFormat('?[...Enter your answer]');
+
+      expect(result).toEqual({
+        placeholder: 'Enter your answer',
+        isMultiSelect: false,
+      });
+    });
+
     test('Test Button Syntax Parsing', () => {
       const result = parser.parseToRemarkFormat(
         '?[Save//save | Cancel//cancel]'
@@ -68,6 +77,17 @@ describe('InteractionParser Sample and Test', () => {
           'Pause',
           'Stop',
         ]);
+      }
+    });
+
+    test('Test Non-Variable Text Input Parsing', () => {
+      const result = parser.parse('?[...Describe your goal]');
+
+      expect(result.type).toBe(InteractionType.TEXT_ONLY);
+      if (result.type === InteractionType.TEXT_ONLY) {
+        expect(result.variable).toBeUndefined();
+        expect(result.question).toBe('Describe your goal');
+        expect(result.isMultiSelect).toBe(false);
       }
     });
 
@@ -154,6 +174,11 @@ describe('InteractionParser Sample and Test', () => {
           input: '?[%{{username}}...Enter your username]',
           expected: 'TEXT_ONLY',
           description: 'Pure Text Input',
+        },
+        {
+          input: '?[...Enter your username]',
+          expected: 'TEXT_ONLY',
+          description: 'Pure Text Input Without Variable',
         },
         {
           input: '?[%{{theme}} Light | Dark]',

--- a/tests/remark-flow.test.ts
+++ b/tests/remark-flow.test.ts
@@ -105,6 +105,25 @@ describe('remarkFlow', () => {
     expect(customNodes[0].data.hProperties.placeholder).toBe('enter your name');
   });
 
+  test('should handle placeholder-only syntax without variable', () => {
+    const textNode = createTextNode('Input: ?[...enter your answer]');
+    const parentNode = createParentNode([textNode]);
+
+    const plugin = remarkFlow();
+    plugin(parentNode);
+
+    const customNodes = findCustomNodes(parentNode);
+    expect(customNodes).toHaveLength(1);
+    expect(customNodes[0].data.hName).toBe('custom-variable');
+    expect(customNodes[0].data.hProperties.variableName).toBeUndefined();
+    expect(customNodes[0].data.hProperties.buttonTexts).toBeUndefined();
+    expect(customNodes[0].data.hProperties.buttonValues).toBeUndefined();
+    expect(customNodes[0].data.hProperties.placeholder).toBe(
+      'enter your answer'
+    );
+    expect(customNodes[0].data.hProperties.isMultiSelect).toBe(false);
+  });
+
   test('should handle Chinese button text with valid separators', () => {
     const textNode1 = createTextNode('变量: ?[%{{color}} 红色 | 蓝色]');
     const textNode2 = createTextNode(' 按钮: ?[提交]');

--- a/tests/remark-interaction.test.ts
+++ b/tests/remark-interaction.test.ts
@@ -26,6 +26,25 @@ describe('remarkInteraction (Merged Plugin)', () => {
       expect(props.buttonValues).toBeUndefined();
     });
 
+    test('should parse text-only input without variable', () => {
+      const textNode = createTextNode('Input: ?[...enter your answer]');
+      const parentNode = createParentNode([textNode]);
+
+      const plugin = remarkInteraction();
+      plugin(parentNode);
+
+      const customNodes = findCustomNodes(parentNode);
+      expect(customNodes).toHaveLength(1);
+      expect(customNodes[0].data.hName).toBe('custom-variable');
+
+      const props = customNodes[0].data.hProperties;
+      expect(props.variableName).toBeUndefined();
+      expect(props.placeholder).toBe('enter your answer');
+      expect(props.isMultiSelect).toBe(false);
+      expect(props.buttonTexts).toBeUndefined();
+      expect(props.buttonValues).toBeUndefined();
+    });
+
     test('should parse buttons-only', () => {
       const textNode = createTextNode(
         'Select: ?[%{{color}} red | blue | green]'


### PR DESCRIPTION
## Summary

- Treat variable-free `?[...placeholder]` syntax as text-only input instead of a button.
- Preserve existing variable-backed text input and non-assignment button behavior.
- Add parser and plugin-level regression coverage for variable-free text input.

## Validation

- `npm test`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `git diff --check`