### PR TITLE
chore: release 1.2.0

### DIFF
--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -64,7 +64,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # npm 12 (needed for OIDC trusted publishing) requires node >= 22
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remark-flow",
-  "version": "0.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remark-flow",
-      "version": "0.1.2",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "unist": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -84,5 +84,5 @@
     "test:watch": "jest --watch"
   },
   "types": "dist/index.d.ts",
-  "version": "0.1.3"
+  "version": "1.2.0"
 }


### PR DESCRIPTION
Merge back the 1.2.0 release: the version bump committed by the publish workflow, plus a workflow fix (node 22 — npm 12, required for OIDC trusted publishing, does not support node 20).

`remark-flow@1.2.0` is live on npm with the `latest` dist-tag (previously stuck on `0.1.3-beta.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)